### PR TITLE
Adds lazy loading support to binding methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Features:
 - Named dependencies (bindings)
 - Resolve by functions, variables, and structs
 - Must helpers that convert errors to panics
+- Optional lazy loading of bindings
 - Global instance for small applications
 
 ## Documentation
@@ -280,14 +281,29 @@ container.MustCall(c, func(s Shape) {
 
 // Other Must Helpers:
 // container.MustSingleton()
+// container.MustSingletonLazy()
 // container.MustNamedSingleton()
+// container.MustNamedSingletonLazy()
 // container.MustTransient()
+// container.MustTransientLazy()
 // container.MustNamedTransient()
+// container.MustNamedTransientLazy()
 // container.MustCall()
 // container.MustResolve()
 // container.MustNamedResolve()
 // container.MustFill()
 ```
+
+### Lazy Binding
+Both the named and normal `Singleton` and `Transient` binding calls have a lazy version.
+Lazy versions defer calling the provided resolver function until the first time the dependency is resolved.
+For singletons the resolver function is called only once and the result is stored. Transient
+
+Lazy binding calls include:
+* container.SingletonLazy()
+* container.NamedSingletonLazy()
+* container.TransientLazy()
+* container.NamedTransientLazy()
 
 ### Performance
 The package Container inevitably uses reflection for binding and resolving processes. 

--- a/global.go
+++ b/global.go
@@ -8,9 +8,19 @@ func Singleton(resolver interface{}) error {
 	return Global.Singleton(resolver)
 }
 
+// SingletonLazy calls the same method of the global concrete.
+func SingletonLazy(resolver interface{}) error {
+	return Global.SingletonLazy(resolver)
+}
+
 // NamedSingleton calls the same method of the global concrete.
 func NamedSingleton(name string, resolver interface{}) error {
 	return Global.NamedSingleton(name, resolver)
+}
+
+// NamedSingletonLazy calls the same method of the global concrete.
+func NamedSingletonLazy(name string, resolver interface{}) error {
+	return Global.NamedSingletonLazy(name, resolver)
 }
 
 // Transient calls the same method of the global concrete.
@@ -18,9 +28,19 @@ func Transient(resolver interface{}) error {
 	return Global.Transient(resolver)
 }
 
+// TransientLazy calls the same method of the global concrete.
+func TransientLazy(resolver interface{}) error {
+	return Global.TransientLazy(resolver)
+}
+
 // NamedTransient calls the same method of the global concrete.
 func NamedTransient(name string, resolver interface{}) error {
 	return Global.NamedTransient(name, resolver)
+}
+
+// NamedTransientLazy calls the same method of the global concrete.
+func NamedTransientLazy(name string, resolver interface{}) error {
+	return Global.NamedTransientLazy(name, resolver)
 }
 
 // Reset calls the same method of the global concrete.

--- a/global_test.go
+++ b/global_test.go
@@ -1,15 +1,25 @@
 package container_test
 
 import (
+	"testing"
+
 	"github.com/golobby/container/v3"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestSingleton(t *testing.T) {
 	container.Reset()
 
 	err := container.Singleton(func() Shape {
+		return &Circle{a: 13}
+	})
+	assert.NoError(t, err)
+}
+
+func TestSingletonLazy(t *testing.T) {
+	container.Reset()
+
+	err := container.SingletonLazy(func() Shape {
 		return &Circle{a: 13}
 	})
 	assert.NoError(t, err)
@@ -24,6 +34,15 @@ func TestNamedSingleton(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestNamedSingletonLazy(t *testing.T) {
+	container.Reset()
+
+	err := container.NamedSingletonLazy("rounded", func() Shape {
+		return &Circle{a: 13}
+	})
+	assert.NoError(t, err)
+}
+
 func TestTransient(t *testing.T) {
 	container.Reset()
 
@@ -33,10 +52,28 @@ func TestTransient(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestTransientLazy(t *testing.T) {
+	container.Reset()
+
+	err := container.TransientLazy(func() Shape {
+		return &Circle{a: 13}
+	})
+	assert.NoError(t, err)
+}
+
 func TestNamedTransient(t *testing.T) {
 	container.Reset()
 
 	err := container.NamedTransient("rounded", func() Shape {
+		return &Circle{a: 13}
+	})
+	assert.NoError(t, err)
+}
+
+func TestNamedTransientLazy(t *testing.T) {
+	container.Reset()
+
+	err := container.NamedTransientLazy("rounded", func() Shape {
 		return &Circle{a: 13}
 	})
 	assert.NoError(t, err)

--- a/must.go
+++ b/must.go
@@ -7,9 +7,23 @@ func MustSingleton(c Container, resolver interface{}) {
 	}
 }
 
+// MustSingleton wraps the `SingletonLazy` method and panics on errors instead of returning the errors.
+func MustSingletonLazy(c Container, resolver interface{}) {
+	if err := c.SingletonLazy(resolver); err != nil {
+		panic(err)
+	}
+}
+
 // MustNamedSingleton wraps the `NamedSingleton` method and panics on errors instead of returning the errors.
 func MustNamedSingleton(c Container, name string, resolver interface{}) {
 	if err := c.NamedSingleton(name, resolver); err != nil {
+		panic(err)
+	}
+}
+
+// MustNamedSingleton wraps the `NamedSingletonLazy` method and panics on errors instead of returning the errors.
+func MustNamedSingletonLazy(c Container, name string, resolver interface{}) {
+	if err := c.NamedSingletonLazy(name, resolver); err != nil {
 		panic(err)
 	}
 }
@@ -21,9 +35,23 @@ func MustTransient(c Container, resolver interface{}) {
 	}
 }
 
+// MustTransientLazy wraps the `TransientLazy` method and panics on errors instead of returning the errors.
+func MustTransientLazy(c Container, resolver interface{}) {
+	if err := c.TransientLazy(resolver); err != nil {
+		panic(err)
+	}
+}
+
 // MustNamedTransient wraps the `NamedTransient` method and panics on errors instead of returning the errors.
 func MustNamedTransient(c Container, name string, resolver interface{}) {
 	if err := c.NamedTransient(name, resolver); err != nil {
+		panic(err)
+	}
+}
+
+// MustNamedTransient wraps the `NamedTransientLazy` method and panics on errors instead of returning the errors.
+func MustNamedTransientLazy(c Container, name string, resolver interface{}) {
+	if err := c.NamedTransientLazy(name, resolver); err != nil {
 		panic(err)
 	}
 }

--- a/must_test.go
+++ b/must_test.go
@@ -2,8 +2,9 @@ package container_test
 
 import (
 	"errors"
-	"github.com/golobby/container/v3"
 	"testing"
+
+	"github.com/golobby/container/v3"
 )
 
 func TestMustSingleton_It_Should_Panic_On_Error(t *testing.T) {
@@ -13,6 +14,14 @@ func TestMustSingleton_It_Should_Panic_On_Error(t *testing.T) {
 	container.MustSingleton(c, func() (Shape, error) {
 		return nil, errors.New("error")
 	})
+	t.Errorf("panic expcted.")
+}
+
+func TestMustSingletonLazy_It_Should_Panic_On_Error(t *testing.T) {
+	c := container.New()
+
+	defer func() { recover() }()
+	container.MustSingletonLazy(c, func() {})
 	t.Errorf("panic expcted.")
 }
 
@@ -26,6 +35,14 @@ func TestMustNamedSingleton_It_Should_Panic_On_Error(t *testing.T) {
 	t.Errorf("panic expcted.")
 }
 
+func TestMustNamedSingletonLazy_It_Should_Panic_On_Error(t *testing.T) {
+	c := container.New()
+
+	defer func() { recover() }()
+	container.MustNamedSingletonLazy(c, "name", func() {})
+	t.Errorf("panic expcted.")
+}
+
 func TestMustTransient_It_Should_Panic_On_Error(t *testing.T) {
 	c := container.New()
 
@@ -33,6 +50,24 @@ func TestMustTransient_It_Should_Panic_On_Error(t *testing.T) {
 	container.MustTransient(c, func() (Shape, error) {
 		return nil, errors.New("error")
 	})
+
+	var resVal Shape
+	container.MustResolve(c, &resVal)
+
+	t.Errorf("panic expcted.")
+}
+
+func TestMustTransientLazy_It_Should_Panic_On_Error(t *testing.T) {
+	c := container.New()
+
+	defer func() { recover() }()
+	container.MustTransientLazy(c, func() (Shape, error) {
+		return nil, errors.New("error")
+	})
+
+	var resVal Shape
+	container.MustResolve(c, &resVal)
+
 	t.Errorf("panic expcted.")
 }
 
@@ -43,6 +78,24 @@ func TestMustNamedTransient_It_Should_Panic_On_Error(t *testing.T) {
 	container.MustNamedTransient(c, "name", func() (Shape, error) {
 		return nil, errors.New("error")
 	})
+
+	var resVal Shape
+	container.MustNamedResolve(c, &resVal, "name")
+
+	t.Errorf("panic expcted.")
+}
+
+func TestMustNamedTransientLazy_It_Should_Panic_On_Error(t *testing.T) {
+	c := container.New()
+
+	defer func() { recover() }()
+	container.MustNamedTransientLazy(c, "name", func() (Shape, error) {
+		return nil, errors.New("error")
+	})
+
+	var resVal Shape
+	container.MustNamedResolve(c, &resVal, "name")
+
 	t.Errorf("panic expcted.")
 }
 


### PR DESCRIPTION
Inspired from work by @place1. Adds new Lazy methods that can optionally
be called to lazy bind a resolver to an abstract. The resolver will not be
called until the first time a resolve call is made.

A strong effort was made to not cause regressions or otherwise change the
behavior of the existing API. Minor changes were made to how validation
occurs and in some situations a more verbose error can be presented earlier
in a binding process.